### PR TITLE
Fix 'PHP_EXTNAME_SHARED' is undefined

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -4,6 +4,6 @@
 ARG_WITH("vips", "for vips support", "no");
 
 if (PHP_VIPS != "no") {
-  EXTENSION("vips", "vips.c", PHP_EXTNAME_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+  EXTENSION("vips", "vips.c", PHP_VIPS_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 }
 


### PR DESCRIPTION
I tried to build the extension on Windows for PHP 7.3.0 and get this error `C:\php-sdk\php-7.3.0\vc15\x64\php-7.3.0-src\configure.js(6120, 3) Microsoft JScript runtime error: 'PHP_EXTNAME_SHARED' is undefined` when running `configure --disable-all --enable-cli --with-vips`.

It seems the same issue is causing pecl.php.net not being able build the Windows binaries:
https://windows.php.net/downloads/pecl/releases/vips/1.0.9/logs/php_vips-1.0.9-7.2-ts-vc15-x64-logs.zip  -> configure-php_vips-1.0.9-7.2-ts-vc15-x64.txt
https://windows.php.net/downloads/pecl/releases/vips/1.0.9/

I have not been able to find the docs describing what the third argument for the EXTENSION function in the config.w32 files does but looking at official extensions they pass PHP_ extension name _SHARED.

Changing the variable name from:
```
EXTENSION("vips", "vips.c", PHP_EXTNAME_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
```

to:
```
EXTENSION("vips", "vips.c", PHP_VIPS_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
```

fixes the issue and now executes `configure --disable-all --enable-cli --with-vips` without error.