### PR TITLE
Ensure extension is linked with `-Wl,-z,nodelete`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+m4/** linguist-generated=true linguist-vendored=true

--- a/config.m4
+++ b/config.m4
@@ -1,6 +1,11 @@
 dnl $Id$
 dnl config.m4 for extension vips
 
+m4_include(m4/ax_require_defined.m4)
+m4_include(m4/ax_append_flag.m4)
+m4_include(m4/ax_check_link_flag.m4)
+m4_include(m4/ax_append_link_flags.m4)
+
 PHP_ARG_WITH(vips, for vips support,
 [  --with-vips             Include vips support])
 
@@ -34,6 +39,10 @@ if test x"$PHP_VIPS" != x"no"; then
     AC_MSG_ERROR([libvips not found.  Check config.log for more information.])
   ],[$VIPS_LIBS]
   )
+
+  # Mark DSO non-deletable at runtime.
+  # See: https://github.com/libvips/php-vips-ext/issues/43
+  AX_APPEND_LINK_FLAGS([-Wl,-z,nodelete])
 
   AC_DEFINE(HAVE_VIPS, 1, [Whether you have vips])
   PHP_NEW_EXTENSION(vips, vips.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 $VIPS_CFLAGS)

--- a/m4/ax_append_flag.m4
+++ b/m4/ax_append_flag.m4
@@ -1,0 +1,50 @@
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 8
+
+AC_DEFUN([AX_APPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_APPEND(FLAGS,[" $1"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/m4/ax_append_link_flags.m4
+++ b/m4/ax_append_link_flags.m4
@@ -1,0 +1,44 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_append_link_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_LINK_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the linker works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the linker's flags (LDFLAGS) is
+#   used. During the check the flag is always added to the linker's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and AX_CHECK_LINK_FLAG.
+#   Please keep this macro in sync with AX_APPEND_COMPILE_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AC_DEFUN([AX_APPEND_LINK_FLAGS],
+[AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_LINK_FLAG([$flag], [AX_APPEND_FLAG([$flag], [m4_default([$2], [LDFLAGS])])], [], [$3], [$4])
+done
+])dnl AX_APPEND_LINK_FLAGS

--- a/m4/ax_check_link_flag.m4
+++ b/m4/ax_check_link_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS

--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/package.xml
+++ b/package.xml
@@ -42,6 +42,13 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <file role='src' name='php_vips.h'/>
    <file role='src' name='vips.c'/>
 
+   <dir name="m4">
+    <file role='src' name='ax_append_flag.m4'/>
+    <file role='src' name='ax_append_link_flags.m4'/>
+    <file role='src' name='ax_check_link_flag.m4'/>
+    <file role='src' name='ax_require_defined.m4'/>
+   </dir>
+
    <dir name="tests">
     <file role='test' name='001.phpt'/>
     <file role='test' name='002.phpt'/>


### PR DESCRIPTION
As discussed in #43, this ensures that the extension is linked with `-Wl,-z,nodelete`. An advantage of doing this is that the `apachectl graceful` workaround introduced in commit https://github.com/libvips/php-vips-ext/commit/d5e34e866bf9672017219d58cccfdc34f8e6c712 and https://github.com/libvips/php-vips-ext/commit/ed9f4243a34c0f57c8c57485e2650bbaa4e2a38e is probably no longer needed.

The removal of the `apachectl graceful` workaround was verified with this Dockerfile (since I couldn't reproduce that behavior locally with version 1.0.2 of the extension).
<details>
  <summary>Details</summary>
  
```Dockerfile
FROM ubuntu:bionic

ENV DEBIAN_FRONTEND=noninteractive
ENV NO_INTERACTION=1

ENV APACHE_RUN_USER=www-data
ENV APACHE_RUN_GROUP=www-data
ENV APACHE_LOG_DIR=/var/log/apache2

RUN apt-get update \
    && apt-get upgrade -y \
    && apt-get install -y \
        git \
        build-essential \
        unzip \
        wget \
        pkg-config

# stuff we need to build our own libvips
# glib and expat are the only required ones, the others are optional and
# enable features like jpeg load etc.
# you'll probably want to custiomise this list
RUN apt-get install -y \
    libexif-dev \
    libexpat-dev \
    libglib2.0-dev \
    libjpeg-dev \
    libtiff-dev \
    liblcms2-dev \
    liborc-dev \
    libpng-dev \
    libpoppler-glib-dev \
    librsvg2-dev

WORKDIR /usr/local/src

ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
ARG VIPS_VERSION=8.11.3

RUN wget $VIPS_URL/v$VIPS_VERSION/vips-$VIPS_VERSION.tar.gz \
    && tar xf vips-$VIPS_VERSION.tar.gz \
    && cd vips-$VIPS_VERSION \
    && ./configure --prefix=/usr/local --disable-static \
    && make V=0 \
    && make install

# php layers
RUN apt-get install -y \
    php-dev \
    php-pear

# web stuff
RUN apt-get install -y \
    apache2 \
    libapache2-mod-php

# install the latest version of the php vips extension
# (to verify `apachectl graceful` is functional)
#RUN pecl install vips

# install version 1.0.2 of the php vips extension
# (to verify `apachectl graceful` is broken)
#RUN pecl install vips-1.0.2

# install the php vips extension from source
# (to verify `apachectl graceful` is still functional)
RUN git clone https://github.com/kleisauke/php-vips-ext.git --branch z_nodelete --single-branch \
    && cd php-vips-ext \
    && phpize \
    && ./configure \
    && make \
    && make test \
    && make install

# enable the vips.so extension for cli
RUN echo "extension=vips.so" > /etc/php/7.2/mods-available/vips.ini \
    && ln -s /etc/php/7.2/mods-available/vips.ini \
        /etc/php/7.2/cli/conf.d/20-vips.ini

# enable the vips.so extension for apache
RUN ln -s /etc/php/7.2/mods-available/vips.ini \
    /etc/php/7.2/apache2/conf.d/20-vips.ini

EXPOSE 80

WORKDIR /var/www/html

CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
```

```bash
$ docker pull ubuntu:bionic
$ docker build -t php-vips-ext .
$ docker run -d -p 8080:80 --name=php-vips-ext-apache2 php-vips-ext
$ docker exec -it php-vips-ext-apache2 /bin/bash
$ wget https://images.weserv.nl/zebra.jpg
$ cat <<'EOF' > index.php
<?php

    echo "Hello world!<br>\n";

    $filename = "zebra.jpg";

    $x = vips_image_new_from_file($filename)["out"];
    if(!$x) {
        echo "failed to open image<br>\n";
        echo "vips error log is " . vips_error_buffer() . "\n<br>";
    }
    else {
        $width = vips_image_get($x, "width")["out"];

        echo "image " . $filename . " is " . $width . " pixels across\n";
    }
?>
EOF
$ rm index.html
# Visit http://localhost:8080/index.php
# (should print: `image zebra.jpg is 4120 pixels across`)

$ cat /var/log/apache2/error.log
$ apachectl graceful
$ cat /var/log/apache2/error.log
$ ps aux | grep apache

# Visit http://localhost:8080/index.php again
```
</details>

Note that I'm not sure if linking with `-Wl,-z,nodelete` may cause undesirable side effects (it's probably fine since the whole of GLib is linked with this flag).

Marked this PR as a draft due to these TODO-items:
 - [x] Was the `apachectl graceful` workaround only for Linux? If not, we may need to verify whether this PR also works on macOS.
 - [x] Should we re-introduce the call to `vips_shutdown` in `PHP_MSHUTDOWN_FUNCTION`?